### PR TITLE
Removes unsuported Node.js versions from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ node_js:
   - "10"
   - "9"
   - "8"
-  - "7"
   - "6"
-  - "5"
   - "4"
 cache:
   directories:


### PR DESCRIPTION
See https://github.com/nodejs/Release#release-schedule

[skip ci]